### PR TITLE
Use GameRegistry.findUniqueIdentifierFor().modId instead of finding ModContainer

### DIFF
--- a/src/main/java/tombenpotter/sanguimancy/util/EventHandler.java
+++ b/src/main/java/tombenpotter/sanguimancy/util/EventHandler.java
@@ -7,13 +7,12 @@ import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
 import amerifrance.guideapi.api.GuideRegistry;
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
-import cpw.mods.fml.common.registry.GameData;
+import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.Tessellator;
@@ -317,17 +316,12 @@ public class EventHandler {
     public void onSanguimancyItemTooltip(ItemTooltipEvent event) {
         ItemStack stack = event.itemStack;
 
-        try {
-            ModContainer mod = GameData.findModOwner(GameData.itemRegistry.getNameForObject(stack.getItem()));
-            String modname = mod == null ? "Minecraft" : mod.getName();
-            if (modname.equals(Sanguimancy.name) && stack.stackTagCompound != null && stack.stackTagCompound.hasKey("ownerName")) {
-                if (GuiScreen.isShiftKeyDown()) {
-                    event.toolTip.add((StatCollector.translateToLocal("info.Sanguimancy.tooltip.owner") + ": " + RandomUtils.getItemOwner(stack)));
-                }
-            }
-        } catch (NullPointerException e) {
-            Sanguimancy.logger.info("No mod found for this item");
-        }
+		String modId = GameRegistry.findUniqueIdentifierFor(stack.getItem()).modId;
+		if (modId.equals(Sanguimancy.modid) && stack.stackTagCompound != null && stack.stackTagCompound.hasKey("ownerName")) {
+			if (GuiScreen.isShiftKeyDown()) {
+				event.toolTip.add(StatCollector.translateToLocal("info.Sanguimancy.tooltip.owner") + ": " + stack.stackTagCompound.getString("ownerName"));
+			}
+		}
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This prevents NPEs from being thrown extremely often during the tooltip event.

Also remove unnecessary/redundant call to RandomUtils.getItemOwner