### PR TITLE
Fixed LP usage from ritual.

### DIFF
--- a/src/main/java/tombenpotter/sanguimancy/rituals/RitualEffectDrillOfTheDead.java
+++ b/src/main/java/tombenpotter/sanguimancy/rituals/RitualEffectDrillOfTheDead.java
@@ -80,7 +80,7 @@ public class RitualEffectDrillOfTheDead extends RitualEffect {
                     }
                 }
             }
-            SoulNetworkHandler.syphonFromNetwork(owner, getCostPerRefresh());
+            SoulNetworkHandler.syphonFromNetwork(owner, getCostPerRefresh() * entityCount);
         }
     }
 


### PR DESCRIPTION
Activated ritual always took 75LP/s regardless of entities or action. Just simply added a multiplier to the SoulNetworkHandler.syphonFromNetwork function.