### PR TITLE
Fixed LP Usage from Drill of the Dead.

### DIFF
--- a/src/main/java/tombenpotter/sanguimancy/rituals/RitualEffectDrillOfTheDead.java
+++ b/src/main/java/tombenpotter/sanguimancy/rituals/RitualEffectDrillOfTheDead.java
@@ -80,7 +80,7 @@ public class RitualEffectDrillOfTheDead extends RitualEffect {
                     }
                 }
             }
-            SoulNetworkHandler.syphonFromNetwork(owner, getCostPerRefresh());
+            SoulNetworkHandler.syphonFromNetwork(owner, getCostPerRefresh() * entityCount);
         }
     }
 


### PR DESCRIPTION
The ritual always used a constant LP regardless of entities. Fixed by multiplying the LP cost by the number of entities.